### PR TITLE
fix: Add `allow_greedy` flag to logos skip pattern to fix compilation with newer Rust

### DIFF
--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -18,7 +18,6 @@ fn unterminated_string_literal(_: &mut Lexer<Token>) -> ParseResult<()> {
 #[logos(subpattern float = r"-?(?:([0-9]*[.])?[0-9][0-9_]*)(?:[eE][+-]?[0-9][0-9_]*)?")]
 #[logos(skip r"[ \t\n\f\r]+")]
 #[logos(skip(r"#[^\r\n]*(\r\n|\n)?", allow_greedy = true))] // single line comment
-
 pub enum Token {
     #[token(b"or", ignore(case))]
     OpOr,


### PR DESCRIPTION
## Problem

Building valkey-timeseries with Rust 1.88+ (beta/nightly) fails with the following error:

```
...
#14 22.40    Compiling rand v0.9.2
#14 24.90    Compiling croaring v2.5.2
#14 25.96 error: This pattern contains an unbounded greedy dot repetition, i.e. `.*` or `.+` (or a character class that is equivalent to a dot, i.e., `[^\n]*`). This will cause the entirety of the input to be read for every token. Consider making your repetition non-greedy or changing it to a more specific character class. If this is the intended behavior, add #[regex(..., allow_greedy = true)] or#[logos(skip(..., allow_greedy = true))]
#14 25.96   --> src/parser/lex.rs:20:14
#14 25.96    |
#14 25.96 20 | #[logos(skip r"#[^\r\n]*(\r\n|\n)?")] // single line comment
#14 25.96    |              ^^^^^^^^^^^^^^^^^^^^^^
#14 25.96
#14 27.48 error: could not compile `valkey-timeseries` (lib) due to 1 previous error
#14 ERROR: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 101
```



## Root Cause

The `logos` crate (v0.16+) now enforces stricter validation of regex patterns and requires 
explicit acknowledgment of greedy patterns that could potentially consume the entire input.

## Solution

Add `allow_greedy = true` to the skip pattern for single-line comments, as this is the 
intended behavior (comments should consume until end of line).


### Testing
- Tested with Rust 1.94.0-beta.2 (23a44d3c7 2026-01-25)
- All existing tests pass
- Module loads successfully in Valkey 9.0