### PR TITLE
Change the type name from `vktseries` to `TSDB-TYPE` to match RedisTimeSeries

### DIFF
--- a/src/series/series_data_type.rs
+++ b/src/series/series_data_type.rs
@@ -27,7 +27,7 @@ use valkey_module_macros::flush_event_handler;
 const TIMESERIES_TYPE_ENCODING_VERSION: i32 = 1;
 
 pub static VK_TIME_SERIES_TYPE: ValkeyType = ValkeyType::new(
-    "vktseries",
+    "TSDB-TYPE",
     TIMESERIES_TYPE_ENCODING_VERSION,
     RedisModuleTypeMethods {
         version: valkey_module::TYPE_METHOD_VERSION,


### PR DESCRIPTION
## Problem

When using the `TYPE` command on a TimeSeries key, valkey-timeseries returns `vktseries`:
```
127.0.0.1:6379> TS.CREATE mykey
OK

127.0.0.1:6379> TYPE mykey
vktseries
```

However, _RedisTimeSeries_ returns `TSDB-TYPE` for the same operation. This causes compatibility 
issues with applications that check the key type to determine how to handle the data. These applications fail or behave incorrectly when they encounter `vktseries` instead of the expected `TSDB-TYPE`.


## Testing

```
127.0.0.1:6379> TS.CREATE mykey
OK

127.0.0.1:6379> TYPE mykey
TSDB-TYPE
```

## Compatibility Notes

- This is a **breaking change** for any code that explicitly checks for `vktseries`
- This improves compatibility with _RedisTimeSeries_ client libraries
- Error messages already use `TSDB:` prefix, so they remain

## Alternative Implementation

Alternatively, this could be implemented as a compile-time feature flag or runtime configuration option to allow users to choose between:
- `vktseries` (Valkey-native naming)
- `TSDB-TYPE` (RedisTimeSeries compatibility)


In that case we can create a new PR, just let me know.