### PR TITLE
Run `ts.outliers` in a background thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ blart = "0.4"
 bon = "3.9"
 byte-pool = "0.2.4"
 cfg-if = "1.0.4"
-croaring = "2.5"
+croaring = "2.6"
 enquote = "1.1.0"
 enum_dispatch = "0.3.13"
 get-size2 = { version = "0.7", features = ["derive"] }

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -10,12 +10,14 @@ use crate::commands::{
 };
 use crate::common::Sample;
 use crate::common::hash::IntSet;
+use crate::common::threads::spawn;
 use crate::error_consts;
-use crate::series::get_timeseries;
+use crate::series::{TimestampRange, get_timeseries};
 use std::collections::HashMap;
 use valkey_module::redisvalue::ValkeyValueKey;
 use valkey_module::{
-    AclPermissions, Context, NextArg, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
+    AclPermissions, Context, MODULE_CONTEXT, NextArg, ThreadSafeContext, ValkeyError, ValkeyResult,
+    ValkeyString, ValkeyValue,
 };
 
 const MAX_SEASONALITY_PERIODS: usize = 4;
@@ -52,7 +54,7 @@ pub fn ts_outliers_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 
     let mut args = args.into_iter().skip(1).peekable();
 
-    let key = args.next_arg()?;
+    let key = args.next_string()?;
     // Parse timestamps
     let date_range = parse_timestamp_range(&mut args)?;
 
@@ -91,25 +93,70 @@ pub fn ts_outliers_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
         }
     }
 
-    let Some(series) = get_timeseries(ctx, &key, Some(AclPermissions::ACCESS), true)? else {
-        return Err(ValkeyError::Str(error_consts::KEY_NOT_FOUND));
-    };
-
-    // Get the time series data for the specified range
-    let (start, end) = date_range.get_series_range(&series, None, false);
-    let samples = series.get_range(start, end);
-
-    let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
-
     let mut options = options.unwrap_or_default();
     options.seasonality = seasonality;
 
-    // Perform analysis detection
-    let result = detect_anomalies(&values, options)
-        .map_err(|e| ValkeyError::String(format!("TSDB: outlier detection failed: {e}")))?;
+    process_request(
+        ctx,
+        key,
+        date_range,
+        options,
+        anomaly_direction,
+        output_format,
+    )
+}
 
-    // Format result based on the requested format
-    format_output(result, samples, anomaly_direction, output_format)
+fn process_request(
+    ctx: &Context,
+    key: String,
+    date_range: TimestampRange,
+    options: AnomalyOptions,
+    anomaly_direction: AnomalyDirection,
+    output_format: OutputFormat,
+) -> ValkeyResult {
+    let blocked_client = ctx.block_client();
+    spawn(move || {
+        let thread_ctx = ThreadSafeContext::with_blocked_client(blocked_client);
+
+        // Acquire module context and fetch samples inside a small scope so we don't hold the lock
+        // longer than necessary.
+        let samples_res = {
+            let ctx = MODULE_CONTEXT.lock();
+            let key = ctx.create_string(key.as_bytes());
+            match get_timeseries(&ctx, &key, Some(AclPermissions::ACCESS), false) {
+                Ok(Some(series)) => {
+                    let (start, end) = date_range.get_series_range(&series, None, false);
+                    Ok(series.get_range(start, end))
+                }
+                Ok(None) => Err(ValkeyError::Str(error_consts::KEY_NOT_FOUND)),
+                Err(e) => Err(e),
+            }
+        };
+
+        match samples_res {
+            Err(e) => {
+                thread_ctx.reply(Err(e));
+            }
+            Ok(samples) => {
+                let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
+                match detect_anomalies(&values, options) {
+                    Err(err) => {
+                        thread_ctx.reply(Err(ValkeyError::String(format!(
+                            "TSDB: outlier detection failed: {err}"
+                        ))));
+                    }
+                    Ok(result) => {
+                        let reply =
+                            format_output(result, samples, anomaly_direction, output_format);
+                        thread_ctx.reply(reply);
+                    }
+                }
+            }
+        }
+    });
+
+    // Reply will be sent from the background thread
+    Ok(ValkeyValue::NoReply)
 }
 
 fn parse_method_options(

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -16,8 +16,8 @@ use crate::series::{TimestampRange, get_timeseries};
 use std::collections::HashMap;
 use valkey_module::redisvalue::ValkeyValueKey;
 use valkey_module::{
-    AclPermissions, Context, MODULE_CONTEXT, NextArg, ThreadSafeContext, ValkeyError, ValkeyResult,
-    ValkeyString, ValkeyValue,
+    AclPermissions, Context, NextArg, ThreadSafeContext, ValkeyError, ValkeyResult, ValkeyString,
+    ValkeyValue,
 };
 
 const MAX_SEASONALITY_PERIODS: usize = 4;
@@ -54,7 +54,7 @@ pub fn ts_outliers_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 
     let mut args = args.into_iter().skip(1).peekable();
 
-    let key = args.next_string()?;
+    let key = args.next_arg()?;
     // Parse timestamps
     let date_range = parse_timestamp_range(&mut args)?;
 
@@ -98,7 +98,7 @@ pub fn ts_outliers_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 
     process_request(
         ctx,
-        key,
+        key.to_vec(),
         date_range,
         options,
         anomaly_direction,
@@ -108,7 +108,7 @@ pub fn ts_outliers_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 
 fn process_request(
     ctx: &Context,
-    key: String,
+    key: Vec<u8>,
     date_range: TimestampRange,
     options: AnomalyOptions,
     anomaly_direction: AnomalyDirection,
@@ -118,11 +118,9 @@ fn process_request(
     spawn(move || {
         let thread_ctx = ThreadSafeContext::with_blocked_client(blocked_client);
 
-        // Acquire module context and fetch samples inside a small scope so we don't hold the lock
-        // longer than necessary.
         let samples_res = {
-            let ctx = MODULE_CONTEXT.lock();
-            let key = ctx.create_string(key.as_bytes());
+            let ctx = thread_ctx.lock();
+            let key = ctx.create_string(key);
             match get_timeseries(&ctx, &key, Some(AclPermissions::ACCESS), false) {
                 Ok(Some(series)) => {
                     let (start, end) = date_range.get_series_range(&series, None, false);


### PR DESCRIPTION
This pull request refactors the `ts_outliers` command to improve performance and reliability by offloading time series anomaly detection to a background thread. It also includes a dependency update and some minor code improvements. The most important changes are:

### Refactoring and Performance Improvements

* The main anomaly detection logic in `ts_outliers_cmd` is moved into a new `process_request` function, which runs in a background thread using the `spawn` helper. This prevents blocking the main thread during potentially long-running computations.
* The command now uses `ThreadSafeContext` and `block_client` to safely reply to the client from the background thread, improving concurrency and responsiveness.

### Dependency Updates

* The `croaring` crate is updated from version 2.5 to 2.6 in `Cargo.toml`.
