### PR TITLE
Refactor outlier output

### DIFF
--- a/docs/commands/ts.outliers.md
+++ b/docs/commands/ts.outliers.md
@@ -256,10 +256,13 @@ Returns anomaly information based on the `OUTPUT` format:
 
 * `method` - Detection method name (string)
 * `direction` - Detection direction: `positive`, `negative`, or `both` (string)
-* `threshold` - Threshold value used (double)
-* `samples` - All samples with scores: `[[timestamp, value, score], ...]`
-* `scores` - Array of anomaly scores for all samples, aligned by index with `samples`
-* `outliers` - Array of detected outliers (same format as SIMPLE)
+* `samples` - Array of sample tuples: `[[timestamp, value, score, signal], ...]`
+    * `timestamp` - Sample timestamp (integer)
+    * `value` - Original sample value (double)
+    * `score` - Calculated anomaly score (0.0-1.0)
+    * `signal` - Deviation direction (`-1`, `0`, `1`)
+* `parameters` - A map of the parameters used for the detection method.
+* `seasonality` - (optional) A map describing the seasonality parameters used.
 * `method_info` - Algorithm-specific metadata (map, if available):
     * For IQR: `lower_fence`, `upper_fence`
     * For SPC methods (CUSUM, EWMA): `control_limits`, `center_line`
@@ -329,27 +332,21 @@ Get detailed analysis with metadata for API request spikes:
 2) "InterquartileRange"
 3) "direction"
 4) "positive"
-5) "threshold"
-6) "1.5"
-7) "samples"
-8) 1) 1) (integer) 1609459200000
+5) "samples"
+6) 1) 1) (integer) 1609459200000
       2) "125.4"
       3) "0.15"
+      4) (integer) 0
    2) 1) (integer) 1609462800000
       2) "135.2"
       3) "0.18"
+      4) (integer) 1
    ...
-9) "scores"
-10) 1) "0.15"
-   2) "0.18"
-   ...
-11) "outliers"
-12) 1) 1) (integer) 1609462800000
-       2) "850.2"
-       3) (integer) 1
-       4) "0.94"
-13) "method_info"
-14) 1) "lower_fence"
+7) "parameters"
+8) 1) "threshold"
+    2) "1.5"
+9) "method_info"
+10) 1) "lower_fence"
     2) "-50.3"
     3) "upper_fence"
     4) "250.7"

--- a/docs/commands/ts.outliers.md
+++ b/docs/commands/ts.outliers.md
@@ -47,7 +47,7 @@ Controls the output format. One of:
 
 * `SIMPLE` (default) - Returns only the detected outliers
 * `FULL` - Returns all samples with scores, plus anomaly metadata
-* `CLEANED` - Returns normal samples (excluding outliers) and detected anomalies separately
+* `CLEANED` - Returns only normal samples (excluding outliers)
 
 </details>
 
@@ -86,7 +86,7 @@ SEASONALITY [AUTO | period1 ...]
 <details open>
 <summary><code>METHOD</code></summary>
 
-Specifies the outliers detection algorithm. **Required**. The following methods are supported:
+Specifies the outlier detection algorithm. **Required**. The following methods are supported:
 
 #### CUSUM
 
@@ -269,10 +269,7 @@ Returns anomaly information based on the `OUTPUT` format:
 
 #### CLEANED format
 
-**Map reply** with keys:
-
-* `samples` - Normal samples (excluding outliers): `[[timestamp, value], ...]`
-* `outliers` - Detected anomalies: `[[timestamp, value, signal, score], ...]`
+**Array reply:** Cleaned samples only, as `[[timestamp, value], ...]`
 
 ## Complexity
 
@@ -372,21 +369,15 @@ Handle both daily and weekly patterns in hourly traffic data:
 <details open>
 <summary><b>Get cleaned data (anomalies removed)</b></summary>
 
-Extract normal operating data and anomalies separately:
+Extract normal operating data with anomalies removed:
 
 ```valkey-cli
 127.0.0.1:6379> TS.OUTLIERS cpu:usage - + OUTPUT CLEANED DIRECTION BOTH METHOD EWMA ALPHA 0.3
-1) "samples"
-2) 1) 1) (integer) 1609459200000
-      2) "45.2"
-   2) 1) (integer) 1609462800000
-      2) "47.8"
-   ...
-3) "outliers"
-4) 1) 1) (integer) 1609470000000
-      2) "98.5"
-      3) (integer) 1
-      4) "0.91"
+1) 1) (integer) 1609459200000
+   2) "45.2"
+2) 1) (integer) 1609462800000
+   2) "47.8"
+...
 ```
 
 </details>

--- a/src/analysis/outliers/anomalies.rs
+++ b/src/analysis/outliers/anomalies.rs
@@ -119,10 +119,10 @@ impl AnomalyOptions {
 /// println!("Anomalies detected: {}", result.anomalies.len());
 /// ```
 pub fn detect_anomalies(
-    ts: &[f64],
+    values: &[f64],
     options: &AnomalyOptions,
 ) -> TimeSeriesAnalysisResult<AnomalyResult> {
-    let n = ts.len();
+    let n = values.len();
 
     if n < 3 {
         return Err(TimeSeriesAnalysisError::InsufficientData {
@@ -134,25 +134,32 @@ pub fn detect_anomalies(
 
     // Apply seasonal adjustment if requested
     if let Some(adjustment) = &options.seasonality {
-        let adjusted = seasonally_adjust(ts, adjustment)?;
+        let adjusted = seasonally_adjust(values, adjustment)?;
         let mut result = handle_dispatch(&adjusted, options)?;
         // we calculate anomalies on the seasonally adjusted data, but we want to report the original values in the result
         for anomaly in &mut result.anomalies {
-            anomaly.value = ts[anomaly.index];
+            anomaly.value = values[anomaly.index];
         }
         return Ok(result);
     };
 
-    handle_dispatch(ts, options)
+    handle_dispatch(values, options)
 }
 
 fn handle_dispatch(
-    ts: &[f64],
+    values: &[f64],
     options: &AnomalyOptions,
 ) -> TimeSeriesAnalysisResult<AnomalyResult> {
-    let mut detector = build_detector(ts, &options.options)?;
-    detector.train(ts)?;
-    detector.detect(ts)
+    let mut detector = build_detector(values, &options.options)?;
+    detector.train(values)?;
+    let res = detector.detect(values)?;
+    debug_assert_eq!(
+        values.len(),
+        res.scores.len(),
+        "Mismatch between scores.len() and samples.len() in {:?}",
+        options.method()
+    );
+    Ok(res)
 }
 
 fn build_detector(

--- a/src/analysis/outliers/anomalies.rs
+++ b/src/analysis/outliers/anomalies.rs
@@ -90,7 +90,7 @@ impl AnomalyOptions {
 ///
 /// # Arguments
 ///
-/// * `ts` - The time series to analyze
+/// * `values` - The time series to analyze
 /// * `options` - Options controlling the anomaly detection
 ///
 /// # Returns
@@ -103,19 +103,19 @@ impl AnomalyOptions {
 /// use crate::analysis::outliers::anomalies::{detect_anomalies, AnomalyOptions, AnomalyDetectionMethodOptions};
 ///
 /// // Create a time series with some anomalies
-/// let mut ts = vec![0.0; 100];
+/// let mut values = vec![0.0; 100];
 /// for i in 0..100 {
-///     ts[i] = (i as f64 / 10.0).sin();
+///     values[i] = (i as f64 / 10.0).sin();
 /// }
-/// ts[25] = 5.0; // Anomaly
-/// ts[75] = -5.0; // Anomaly
+/// values[25] = 5.0; // Anomaly
+/// values[75] = -5.0; // Anomaly
 ///
 /// let options = AnomalyOptions {
 ///     options: AnomalyDetectionMethodOptions::ZScore(Some(3.0)),
 ///     ..Default::default()
 /// };
 ///
-/// let result = detect_anomalies(&ts, options).unwrap();
+/// let result = detect_anomalies(&values, options).unwrap();
 /// println!("Anomalies detected: {}", result.anomalies.len());
 /// ```
 pub fn detect_anomalies(
@@ -163,17 +163,17 @@ fn handle_dispatch(
 }
 
 fn build_detector(
-    ts: &[f64],
+    values: &[f64],
     method_options: &AnomalyDetectionMethodOptions,
 ) -> TimeSeriesAnalysisResult<Box<dyn BatchOutlierDetector>> {
     let detector: Box<dyn BatchOutlierDetector> = match method_options {
         AnomalyDetectionMethodOptions::Cusum => Box::new(CusumOutlierDetector::default()),
         AnomalyDetectionMethodOptions::Ewma(alpha) => Box::new(EwmaOutlierDetector::from_series(
-            ts,
+            values,
             alpha.unwrap_or(EWMA_DEFAULT_ALPHA),
         )),
         AnomalyDetectionMethodOptions::InterQuartileRange(threshold) => Box::new(
-            IQROutlierDetector::new(ts, threshold.unwrap_or(IQR_DEFAULT_THRESHOLD)),
+            IQROutlierDetector::new(values, threshold.unwrap_or(IQR_DEFAULT_THRESHOLD)),
         ),
         AnomalyDetectionMethodOptions::ZScore(threshold) => Box::new(ZScoreOutlierDetector::new(
             threshold.unwrap_or(ZScoreOutlierDetector::DEFAULT_THRESHOLD),

--- a/src/analysis/outliers/anomalies.rs
+++ b/src/analysis/outliers/anomalies.rs
@@ -120,7 +120,7 @@ impl AnomalyOptions {
 /// ```
 pub fn detect_anomalies(
     ts: &[f64],
-    options: AnomalyOptions,
+    options: &AnomalyOptions,
 ) -> TimeSeriesAnalysisResult<AnomalyResult> {
     let n = ts.len();
 
@@ -146,15 +146,18 @@ pub fn detect_anomalies(
     handle_dispatch(ts, options)
 }
 
-fn handle_dispatch(ts: &[f64], options: AnomalyOptions) -> TimeSeriesAnalysisResult<AnomalyResult> {
-    let mut detector = build_detector(ts, options.options)?;
+fn handle_dispatch(
+    ts: &[f64],
+    options: &AnomalyOptions,
+) -> TimeSeriesAnalysisResult<AnomalyResult> {
+    let mut detector = build_detector(ts, &options.options)?;
     detector.train(ts)?;
     detector.detect(ts)
 }
 
 fn build_detector(
     ts: &[f64],
-    method_options: AnomalyDetectionMethodOptions,
+    method_options: &AnomalyDetectionMethodOptions,
 ) -> TimeSeriesAnalysisResult<Box<dyn BatchOutlierDetector>> {
     let detector: Box<dyn BatchOutlierDetector> = match method_options {
         AnomalyDetectionMethodOptions::Cusum => Box::new(CusumOutlierDetector::default()),
@@ -188,7 +191,7 @@ fn build_detector(
             Box::new(DoubleMadOutlierDetector::with_options(options))
         }
         AnomalyDetectionMethodOptions::Rcf(opts) => {
-            let detector = RcfOutlierDetector::new(opts)
+            let detector = RcfOutlierDetector::new(*opts)
                 .map_err(|e| TimeSeriesAnalysisError::InvalidModel(format!("{e:?}")))?;
             Box::new(detector)
         }

--- a/src/analysis/outliers/double_mad_outlier_detector.rs
+++ b/src/analysis/outliers/double_mad_outlier_detector.rs
@@ -48,7 +48,7 @@ impl DoubleMadOutlierDetector {
 
     /// Construct an untrained detector with the provided options.
     /// Fences will be computed when `train` is called (or on-demand in `detect`).
-    pub fn with_options(options: MADAnomalyOptions) -> Self {
+    pub fn with_options(options: &MADAnomalyOptions) -> Self {
         Self::new(options.k, options.estimator)
     }
 

--- a/src/analysis/outliers/mod.rs
+++ b/src/analysis/outliers/mod.rs
@@ -20,6 +20,7 @@ mod zscore_outlier_detector;
 
 pub use anomalies::*;
 pub use esd_outlier_detector::*;
+pub use ewma_outlier_detector::*;
 pub use rcf_outlier_detector::*;
 pub use smoothed_zscores::*;
 

--- a/src/analysis/outliers/rcf_outlier_detector.rs
+++ b/src/analysis/outliers/rcf_outlier_detector.rs
@@ -87,11 +87,15 @@ pub struct RCFOptions {
     pub parallel_enabled: Option<bool>,
 }
 
+pub const RCF_DEFAULT_NUM_TREES: usize = 100;
+pub const RCF_DEFAULT_SAMPLE_SIZE: usize = 256;
+pub const RCF_DEFAULT_TIME_DECAY: f64 = 0.0;
+
 impl Default for RCFOptions {
     fn default() -> Self {
         Self {
-            num_trees: Some(100),
-            sample_size: Some(256),
+            num_trees: Some(RCF_DEFAULT_NUM_TREES),
+            sample_size: Some(RCF_DEFAULT_SAMPLE_SIZE),
             threshold: None,
             time_decay: None,
             shingle_size: None,
@@ -105,8 +109,8 @@ impl RCFOptions {
     /// Create RCFOptions with default values overridden by provided ones.
     pub fn with_overrides(overrides: RCFOptions) -> Self {
         RCFOptions {
-            num_trees: overrides.num_trees.or(Some(100)),
-            sample_size: overrides.sample_size.or(Some(256)),
+            num_trees: overrides.num_trees.or(Some(RCF_DEFAULT_NUM_TREES)),
+            sample_size: overrides.sample_size.or(Some(RCF_DEFAULT_SAMPLE_SIZE)),
             threshold: overrides.threshold,
             time_decay: overrides.time_decay,
             shingle_size: overrides.shingle_size,
@@ -130,7 +134,7 @@ impl RCFOptions {
 
         // Missing values fall back to the same defaults used elsewhere.
         let num_trees = self.num_trees.unwrap_or(100);
-        let sample_size = self.sample_size.unwrap_or(256).max(2); // avoid log2(0/1)
+        let sample_size = self.sample_size.unwrap_or(RCF_DEFAULT_SAMPLE_SIZE).max(2); // avoid log2(0/1)
         let shingle_size = self.shingle_size.unwrap_or(1).max(1);
 
         // Univariate base dimension = 1, so the effective dimension is just the shingle size.

--- a/src/analysis/outliers/rcf_outlier_detector.rs
+++ b/src/analysis/outliers/rcf_outlier_detector.rs
@@ -89,7 +89,6 @@ pub struct RCFOptions {
 
 pub const RCF_DEFAULT_NUM_TREES: usize = 100;
 pub const RCF_DEFAULT_SAMPLE_SIZE: usize = 256;
-pub const RCF_DEFAULT_TIME_DECAY: f64 = 0.0;
 
 impl Default for RCFOptions {
     fn default() -> Self {

--- a/src/analysis/outliers/zscore_outlier_detector.rs
+++ b/src/analysis/outliers/zscore_outlier_detector.rs
@@ -289,7 +289,6 @@ mod tests {
     #[test]
     fn test_anomalies_have_high_normalized_scores() {
         // Keep the original intent: anomalies should score "high" on the normalized scale.
-        // Note: score cannot exceed 1.0 anymore, so check for closeness to 1 instead of > 3.
         let mut ts: Vec<f64> = (0..100).map(|i| (i as f64 / 10.0).sin()).collect();
         ts[25] = 5.0;
         ts[75] = -5.0;
@@ -362,7 +361,7 @@ mod tests {
         let ts = vec![1.0, 2.0];
         let options = AnomalyOptions::default();
 
-        let result = detect_anomalies(&ts, options);
+        let result = detect_anomalies(&ts, &options);
         assert!(result.is_err());
 
         // Test with constant time series

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -128,7 +128,7 @@ fn process_request(
     if !should_run_in_background(samples.len(), options.method()) {
         let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
         let reply_ctx = ReplyContext::new(ctx.ctx);
-        return match detect_anomalies(&values, options.clone()) {
+        return match detect_anomalies(&values, &options) {
             Err(err) => Err(ValkeyError::String(format!(
                 "TSDB: outlier detection failed: {err}"
             ))),
@@ -148,7 +148,7 @@ fn process_request(
         let thread_ctx = ThreadSafeReplyContext::with_blocked_client(blocked_client);
 
         let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
-        match detect_anomalies(&values, options.clone()) {
+        match detect_anomalies(&values, &options) {
             Err(err) => {
                 thread_ctx.reply(Err(ValkeyError::String(format!(
                     "TSDB: outlier detection failed: {err}"
@@ -820,9 +820,7 @@ fn reply_with_samples_scores_and_signals(
         .map(|anomaly| (anomaly.index, anomaly))
         .collect();
 
-    let mut count: usize = 0;
-
-    ctx.reply_with_postponed_array();
+    ctx.reply_with_array(samples.len());
 
     for (idx, (sample, &score)) in samples.iter().zip(scores.iter()).enumerate() {
         let mut signal = 0;
@@ -839,11 +837,7 @@ fn reply_with_samples_scores_and_signals(
         ctx.reply_with_double(sample.value);
         ctx.reply_with_double(score);
         ctx.reply_with_integer(signal);
-
-        count += 1;
     }
-
-    ctx.reply_with_array_len(count);
 }
 
 fn reply_with_outlier(ctx: &ReplyContext, outlier: &Anomaly, sample: &Sample) {

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -1,6 +1,7 @@
 use crate::analysis::outliers::{
     Anomaly, AnomalyDetectionMethodOptions, AnomalyDirection, AnomalyMethod, AnomalyOptions,
-    AnomalyResult, ESDOutlierOptions, MADAnomalyOptions, MethodInfo, RCFOptions, RCFThreshold,
+    AnomalyResult, ESDOutlierOptions, EWMA_DEFAULT_ALPHA, MADAnomalyOptions, MethodInfo,
+    RCF_DEFAULT_NUM_TREES, RCF_DEFAULT_SAMPLE_SIZE, RCFOptions, RCFThreshold,
     SmoothedZScoreOptions, detect_anomalies,
 };
 use crate::analysis::seasonality::Seasonality;
@@ -862,7 +863,7 @@ fn reply_with_parameters(
         AnomalyDetectionMethodOptions::Ewma(alpha) => {
             ctx.reply_with_map(1);
             ctx.reply_with_string("alpha");
-            ctx.reply_with_double(alpha.unwrap_or(0.3));
+            ctx.reply_with_double(alpha.unwrap_or(EWMA_DEFAULT_ALPHA));
         }
         AnomalyDetectionMethodOptions::ZScore(_)
         | AnomalyDetectionMethodOptions::ModifiedZScore(_)
@@ -902,9 +903,9 @@ fn reply_with_parameters(
             ctx.reply_with_map(map_len);
 
             ctx.reply_with_string("num_trees");
-            ctx.reply_with_integer(opts.num_trees.unwrap_or(100) as i64);
+            ctx.reply_with_integer(opts.num_trees.unwrap_or(RCF_DEFAULT_NUM_TREES) as i64);
             ctx.reply_with_string("sample_size");
-            ctx.reply_with_integer(opts.sample_size.unwrap_or(256) as i64);
+            ctx.reply_with_integer(opts.sample_size.unwrap_or(RCF_DEFAULT_SAMPLE_SIZE) as i64);
 
             if let Some(threshold_opt) = &opts.threshold {
                 match threshold_opt {

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -1,22 +1,21 @@
 use crate::analysis::outliers::{
-    Anomaly, AnomalyDetectionMethodOptions, AnomalyDirection, AnomalyMethod, AnomalyOptions,
-    AnomalyResult, ESDOutlierOptions, MADAnomalyOptions, MethodInfo, RCFOptions, RCFThreshold,
-    SmoothedZScoreOptions, detect_anomalies,
+    detect_anomalies, Anomaly, AnomalyDetectionMethodOptions, AnomalyDirection, AnomalyMethod,
+    AnomalyOptions, AnomalyResult, ESDOutlierOptions, MADAnomalyOptions, MethodInfo, RCFOptions,
+    RCFThreshold, SmoothedZScoreOptions,
 };
 use crate::analysis::seasonality::Seasonality;
 use crate::commands::{
-    CommandArgIterator, CommandArgToken, parse_command_arg_token, parse_duration_ms,
-    parse_timestamp_range,
+    parse_command_arg_token, parse_timestamp_range, CommandArgIterator,
+    CommandArgToken,
 };
-use crate::common::Sample;
-use crate::common::hash::IntSet;
+use crate::common::hash::{IntMap, IntSet};
 use crate::common::replies::{
-    ReplyContext, ThreadSafeReplyContext, block_client, reply_with_sample,
+    block_client, reply_with_sample, ReplyContext, ThreadSafeReplyContext,
 };
 use crate::common::threads::spawn;
+use crate::common::Sample;
 use crate::error_consts;
-use crate::series::{TimestampRange, get_timeseries};
-use logger_rust::log_debug;
+use crate::series::{get_timeseries, TimestampRange};
 use valkey_module::{
     AclPermissions, Context, NextArg, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
 };
@@ -129,7 +128,7 @@ fn process_request(
     if !should_run_in_background(samples.len(), options.method()) {
         let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
         let reply_ctx = ReplyContext::new(ctx.ctx);
-        return match detect_anomalies(&values, options) {
+        return match detect_anomalies(&values, options.clone()) {
             Err(err) => Err(ValkeyError::String(format!(
                 "TSDB: outlier detection failed: {err}"
             ))),
@@ -139,6 +138,7 @@ fn process_request(
                 samples,
                 anomaly_direction,
                 output_format,
+                &options,
             ),
         };
     }
@@ -148,7 +148,7 @@ fn process_request(
         let thread_ctx = ThreadSafeReplyContext::with_blocked_client(blocked_client);
 
         let values: Vec<f64> = samples.iter().map(|s| s.value).collect();
-        match detect_anomalies(&values, options) {
+        match detect_anomalies(&values, options.clone()) {
             Err(err) => {
                 thread_ctx.reply(Err(ValkeyError::String(format!(
                     "TSDB: outlier detection failed: {err}"
@@ -156,7 +156,14 @@ fn process_request(
             }
             Ok(result) => {
                 let ctx = thread_ctx.get_reply_context();
-                let _ = send_reply(&ctx, result, samples, anomaly_direction, output_format);
+                let _ = send_reply(
+                    &ctx,
+                    result,
+                    samples,
+                    anomaly_direction,
+                    output_format,
+                    &options,
+                );
             }
         }
     });
@@ -176,7 +183,7 @@ fn is_cpu_intensive(method: AnomalyMethod) -> bool {
 fn should_run_in_background(samples: usize, method: AnomalyMethod) -> bool {
     match is_cpu_intensive(method) {
         true => samples > SPAWN_THRESHOLD_SAMPLES,
-        false => samples > 10_000, // For lightweight methods, we can allow more samples before spawning
+        false => samples > 5_000, // For lightweight methods, we can allow more samples before spawning
     }
 }
 
@@ -575,20 +582,6 @@ fn parse_optional_threshold_option(args: &mut CommandArgIterator) -> ValkeyResul
     }
 }
 
-fn parse_single_option_value(
-    iter: &mut CommandArgIterator,
-    option_name: &str,
-) -> ValkeyResult<f64> {
-    if let Some(arg) = iter.next()
-        && arg.as_slice().eq_ignore_ascii_case(option_name.as_bytes())
-    {
-        return parse_single_value(iter, option_name);
-    }
-    Err(ValkeyError::String(format!(
-        "TSDB: Missing or invalid {option_name}"
-    )))
-}
-
 fn parse_single_value(iter: &mut CommandArgIterator, option_name: &str) -> ValkeyResult<f64> {
     let Ok(value_str) = iter.next_str() else {
         return Err(ValkeyError::String(format!(
@@ -603,30 +596,16 @@ fn parse_single_value(iter: &mut CommandArgIterator, option_name: &str) -> Valke
     })
 }
 
-fn parse_single_duration(iter: &mut CommandArgIterator, option_name: &str) -> ValkeyResult<i64> {
-    let Ok(value_str) = iter.next_str() else {
-        return Err(ValkeyError::String(format!(
-            "TSDB: Missing value for {option_name}"
-        )));
-    };
-    let duration = parse_duration_ms(value_str)?;
-    if duration < 0 {
-        return Err(ValkeyError::String(format!(
-            "TSDB: invalid duration for {option_name}"
-        )));
-    }
-    Ok(duration)
-}
-
 fn send_reply(
     ctx: &ReplyContext,
     result: AnomalyResult,
     samples: Vec<Sample>,
     direction: AnomalyDirection,
     output_format: OutputFormat,
+    options: &AnomalyOptions,
 ) -> ValkeyResult {
     match output_format {
-        OutputFormat::Full => reply_output_full(ctx, result, &samples, direction),
+        OutputFormat::Full => reply_output_full(ctx, result, &samples, direction, options),
         OutputFormat::Simple => reply_simple(ctx, result, &samples, direction),
         OutputFormat::Cleaned => reply_cleaned(ctx, result, samples, direction),
     }
@@ -712,17 +691,6 @@ fn reply_with_anomalies(
     }
 
     ctx.reply_with_array_len(count);
-    if count > 3 {
-        log_debug!(
-            "Anomalies: {anomalies:?}",
-            anomalies = result
-                .anomalies
-                .iter()
-                .filter(|o| o.signal.matches_direction(direction))
-                .map(|o| (o.index, o.score))
-                .collect::<Vec<_>>()
-        );
-    }
 }
 
 fn reply_output_full(
@@ -730,36 +698,51 @@ fn reply_output_full(
     result: AnomalyResult,
     samples: &[Sample],
     direction: AnomalyDirection,
+    options: &AnomalyOptions,
 ) -> ValkeyResult {
-    let map_len = 6 + if result.method_info.is_none() { 0 } else { 1 };
+    let mut map_len = 4; // method, direction, samples, parameters
+    if result.method_info.is_some() {
+        map_len += 1;
+    }
+    if options.seasonality.is_some() {
+        map_len += 1;
+    }
 
     ctx.reply_with_map(map_len);
 
     // Add method info
     ctx.reply_with_string("method");
     ctx.reply_with_string(result.method.short_name());
-    ctx.reply_with_string("threshold");
-    ctx.reply_with_double(result.threshold);
     ctx.reply_with_string("direction");
     ctx.reply_with_string(direction.name());
 
-    // Add samples
+    // Add samples with scores and signal
     ctx.reply_with_string("samples");
-    reply_with_samples(ctx, samples);
+    reply_with_samples_scores_and_signals(ctx, samples, &result.anomalies);
 
-    // Add scores
-    ctx.reply_with_string("scores");
-    ctx.reply_with_array(result.scores.len());
-    for (sample, &score) in samples.iter().zip(result.scores.iter()) {
-        ctx.reply_with_array(3);
-        ctx.reply_with_integer(sample.timestamp);
-        ctx.reply_with_double(sample.value);
-        ctx.reply_with_double(score);
+    // Add parameters
+    ctx.reply_with_string("parameters");
+    reply_with_parameters(ctx, &options.options, result.threshold);
+
+    // Add seasonality info if available
+    if let Some(seasonality) = &options.seasonality {
+        ctx.reply_with_string("seasonality");
+        match seasonality {
+            Seasonality::Auto => {
+                ctx.reply_with_map(1);
+                ctx.reply_with_string("method");
+                ctx.reply_with_string("auto");
+            }
+            Seasonality::Periods(periods) => {
+                ctx.reply_with_map(1);
+                ctx.reply_with_string("periods");
+                ctx.reply_with_array(periods.len());
+                for p in periods {
+                    ctx.reply_with_integer(*p as i64);
+                }
+            }
+        }
     }
-
-    // Add anomalies
-    ctx.reply_with_string("outliers");
-    reply_with_anomalies(ctx, &result, samples, direction);
 
     // Add method-specific info if available
     if let Some(method_info) = result.method_info {
@@ -811,10 +794,51 @@ fn reply_with_samples(ctx: &ReplyContext, samples: &[Sample]) {
     }
 }
 
-fn reply_with_scores(ctx: &ReplyContext, scores: &[f64]) {
-    ctx.reply_with_array(scores.len());
-    for &score in scores {
-        ctx.reply_with_double(score);
+fn reply_with_samples_scores_and_signals(
+    ctx: &ReplyContext,
+    samples: &[Sample],
+    anomalies: &[Anomaly],
+) {
+    if anomalies.is_empty() {
+        ctx.reply_with_array(samples.len());
+        for sample in samples {
+            ctx.reply_with_array(4);
+            ctx.reply_with_integer(sample.timestamp);
+            ctx.reply_with_double(sample.value);
+            ctx.reply_with_double(0.0);
+            ctx.reply_with_integer(0);
+        }
+        return;
+    }
+
+    let map: IntMap<usize, &Anomaly> = anomalies
+        .iter()
+        .map(|anomaly| (anomaly.index, anomaly))
+        .collect();
+
+    let first_anomaly_index = anomalies[0].index;
+    let last_anomaly_index = anomalies[anomalies.len() - 1].index;
+
+    ctx.reply_with_array(samples.len());
+    for (idx, sample) in samples.iter().enumerate() {
+        ctx.reply_with_array(4);
+        ctx.reply_with_integer(sample.timestamp);
+        ctx.reply_with_double(sample.value);
+
+        if idx < first_anomaly_index || idx > last_anomaly_index {
+            // If the sample index is outside the range of anomaly indices, we can skip the map lookup
+            ctx.reply_with_double(0.0);
+            ctx.reply_with_integer(0);
+            continue;
+        }
+
+        if let Some(anomaly) = map.get(&idx) {
+            ctx.reply_with_double(anomaly.score);
+            ctx.reply_with_integer(anomaly.signal as i64);
+        } else {
+            ctx.reply_with_double(0.0);
+            ctx.reply_with_integer(0);
+        }
     }
 }
 
@@ -824,4 +848,109 @@ fn reply_with_outlier(ctx: &ReplyContext, outlier: &Anomaly, sample: &Sample) {
     ctx.reply_with_double(sample.value);
     ctx.reply_with_integer(outlier.signal as i64);
     ctx.reply_with_double(outlier.score);
+}
+
+fn reply_with_parameters(
+    ctx: &ReplyContext,
+    options: &AnomalyDetectionMethodOptions,
+    threshold: f64,
+) {
+    match options {
+        AnomalyDetectionMethodOptions::Ewma(alpha) => {
+            ctx.reply_with_map(1);
+            ctx.reply_with_string("alpha");
+            ctx.reply_with_double(alpha.unwrap_or(0.3));
+        }
+        AnomalyDetectionMethodOptions::ZScore(_)
+        | AnomalyDetectionMethodOptions::ModifiedZScore(_)
+        | AnomalyDetectionMethodOptions::InterQuartileRange(_) => {
+            ctx.reply_with_map(1);
+            ctx.reply_with_string("threshold");
+            ctx.reply_with_double(threshold);
+        }
+        AnomalyDetectionMethodOptions::SmoothedZScore(opts) => {
+            ctx.reply_with_map(3);
+            ctx.reply_with_string("threshold");
+            ctx.reply_with_double(opts.threshold);
+            ctx.reply_with_string("lag");
+            ctx.reply_with_integer(opts.lag as i64);
+            ctx.reply_with_string("influence");
+            ctx.reply_with_double(opts.influence);
+        }
+        AnomalyDetectionMethodOptions::Mad(opts)
+        | AnomalyDetectionMethodOptions::DoubleMAD(opts) => {
+            ctx.reply_with_map(2);
+            ctx.reply_with_string("threshold");
+            ctx.reply_with_double(opts.k);
+            ctx.reply_with_string("estimator");
+            ctx.reply_with_string(opts.estimator.alias());
+        }
+        AnomalyDetectionMethodOptions::Rcf(opts) => {
+            let mut map_len = 3; // num_trees, sample_size, threshold
+            if opts.time_decay.is_some() {
+                map_len += 1;
+            }
+            if opts.shingle_size.is_some() {
+                map_len += 1;
+            }
+            if opts.output_after.is_some() {
+                map_len += 1;
+            }
+            ctx.reply_with_map(map_len);
+
+            ctx.reply_with_string("num_trees");
+            ctx.reply_with_integer(opts.num_trees.unwrap_or(100) as i64);
+            ctx.reply_with_string("sample_size");
+            ctx.reply_with_integer(opts.sample_size.unwrap_or(256) as i64);
+
+            if let Some(threshold_opt) = &opts.threshold {
+                match threshold_opt {
+                    RCFThreshold::Contamination(c) => {
+                        ctx.reply_with_string("contamination");
+                        ctx.reply_with_double(*c);
+                    }
+                    RCFThreshold::StdDev(s) => {
+                        ctx.reply_with_string("threshold");
+                        ctx.reply_with_double(*s);
+                    }
+                }
+            } else {
+                // Always include threshold, even if default
+                ctx.reply_with_string("threshold");
+                ctx.reply_with_double(threshold);
+            }
+
+            if let Some(decay) = opts.time_decay {
+                ctx.reply_with_string("decay");
+                ctx.reply_with_double(decay);
+            }
+            if let Some(shingle) = opts.shingle_size {
+                ctx.reply_with_string("shingle_size");
+                ctx.reply_with_integer(shingle as i64);
+            }
+            if let Some(warmup) = opts.output_after {
+                ctx.reply_with_string("output_after");
+                ctx.reply_with_integer(warmup as i64);
+            }
+        }
+        AnomalyDetectionMethodOptions::Esd(opts) => {
+            let o = opts.clone().unwrap_or_default();
+            let mut map_len = 2; // alpha, hybrid
+            if o.max_outliers.is_some() {
+                map_len += 1;
+            }
+            ctx.reply_with_map(map_len);
+            ctx.reply_with_string("alpha");
+            ctx.reply_with_double(o.alpha);
+            ctx.reply_with_string("hybrid");
+            ctx.reply_with_bool(o.hybrid);
+            if let Some(max) = o.max_outliers {
+                ctx.reply_with_string("max_outliers");
+                ctx.reply_with_integer(max as i64);
+            }
+        }
+        AnomalyDetectionMethodOptions::Cusum => {
+            ctx.reply_with_map(0);
+        }
+    }
 }

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -713,7 +713,13 @@ fn reply_output_full(
 
     // Add samples with scores and signal
     ctx.reply_with_string("samples");
-    reply_with_samples_scores_and_signals(ctx, samples, &result.anomalies);
+    reply_with_samples_scores_and_signals(
+        ctx,
+        samples,
+        &result.anomalies,
+        &result.scores,
+        direction,
+    );
 
     // Add parameters
     ctx.reply_with_string("parameters");
@@ -793,14 +799,16 @@ fn reply_with_samples_scores_and_signals(
     ctx: &ReplyContext,
     samples: &[Sample],
     anomalies: &[Anomaly],
+    scores: &[f64],
+    direction: AnomalyDirection,
 ) {
     if anomalies.is_empty() {
         ctx.reply_with_array(samples.len());
-        for sample in samples {
+        for (sample, &score) in samples.iter().zip(scores.iter()) {
             ctx.reply_with_array(4);
             ctx.reply_with_integer(sample.timestamp);
             ctx.reply_with_double(sample.value);
-            ctx.reply_with_double(0.0);
+            ctx.reply_with_double(score);
             ctx.reply_with_integer(0);
         }
         return;
@@ -811,30 +819,30 @@ fn reply_with_samples_scores_and_signals(
         .map(|anomaly| (anomaly.index, anomaly))
         .collect();
 
-    let first_anomaly_index = anomalies[0].index;
-    let last_anomaly_index = anomalies[anomalies.len() - 1].index;
+    let mut count: usize = 0;
 
-    ctx.reply_with_array(samples.len());
-    for (idx, sample) in samples.iter().enumerate() {
+    ctx.reply_with_postponed_array();
+
+    for (idx, (sample, &score)) in samples.iter().zip(scores.iter()).enumerate() {
+        let mut signal = 0;
+
+        if let Some(anomaly) = map
+            .get(&idx)
+            .filter(|a| a.signal.matches_direction(direction))
+        {
+            signal = anomaly.signal as i64;
+        }
+
         ctx.reply_with_array(4);
         ctx.reply_with_integer(sample.timestamp);
         ctx.reply_with_double(sample.value);
+        ctx.reply_with_double(score);
+        ctx.reply_with_integer(signal);
 
-        if idx < first_anomaly_index || idx > last_anomaly_index {
-            // If the sample index is outside the range of anomaly indices, we can skip the map lookup
-            ctx.reply_with_double(0.0);
-            ctx.reply_with_integer(0);
-            continue;
-        }
-
-        if let Some(anomaly) = map.get(&idx) {
-            ctx.reply_with_double(anomaly.score);
-            ctx.reply_with_integer(anomaly.signal as i64);
-        } else {
-            ctx.reply_with_double(0.0);
-            ctx.reply_with_integer(0);
-        }
+        count += 1;
     }
+
+    ctx.reply_with_array_len(count);
 }
 
 fn reply_with_outlier(ctx: &ReplyContext, outlier: &Anomaly, sample: &Sample) {

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -1,21 +1,20 @@
 use crate::analysis::outliers::{
-    detect_anomalies, Anomaly, AnomalyDetectionMethodOptions, AnomalyDirection, AnomalyMethod,
-    AnomalyOptions, AnomalyResult, ESDOutlierOptions, MADAnomalyOptions, MethodInfo, RCFOptions,
-    RCFThreshold, SmoothedZScoreOptions,
+    Anomaly, AnomalyDetectionMethodOptions, AnomalyDirection, AnomalyMethod, AnomalyOptions,
+    AnomalyResult, ESDOutlierOptions, MADAnomalyOptions, MethodInfo, RCFOptions, RCFThreshold,
+    SmoothedZScoreOptions, detect_anomalies,
 };
 use crate::analysis::seasonality::Seasonality;
 use crate::commands::{
-    parse_command_arg_token, parse_timestamp_range, CommandArgIterator,
-    CommandArgToken,
+    CommandArgIterator, CommandArgToken, parse_command_arg_token, parse_timestamp_range,
 };
+use crate::common::Sample;
 use crate::common::hash::{IntMap, IntSet};
 use crate::common::replies::{
-    block_client, reply_with_sample, ReplyContext, ThreadSafeReplyContext,
+    ReplyContext, ThreadSafeReplyContext, block_client, reply_with_sample,
 };
 use crate::common::threads::spawn;
-use crate::common::Sample;
 use crate::error_consts;
-use crate::series::{get_timeseries, TimestampRange};
+use crate::series::{TimestampRange, get_timeseries};
 use valkey_module::{
     AclPermissions, Context, NextArg, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
 };
@@ -444,7 +443,7 @@ fn parse_mad_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
 }
 
 /// doubleMAD [ESTIMATOR <mad-estimator>] [THRESHOLD <value>]
-/// e.g. doubleMAD ESTIMATOR HarrellDavis THRESHOLD 3.0
+/// e.g., doubleMAD ESTIMATOR HarrellDavis THRESHOLD 3.0
 fn parse_double_mad_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptions> {
     let mut double_mad_options = MADAnomalyOptions::default();
 
@@ -607,7 +606,7 @@ fn send_reply(
     match output_format {
         OutputFormat::Full => reply_output_full(ctx, result, &samples, direction, options),
         OutputFormat::Simple => reply_simple(ctx, result, &samples, direction),
-        OutputFormat::Cleaned => reply_cleaned(ctx, result, samples, direction),
+        OutputFormat::Cleaned => reply_cleaned(ctx, &result, &samples, direction),
     }
 }
 
@@ -622,18 +621,14 @@ fn reply_simple(
     Ok(ValkeyValue::NoReply)
 }
 
-/// Returns all samples excluding those that are anomalies in the specified direction, as well as anomalies
+/// Returns only samples excluding anomalies in the specified direction.
 fn reply_cleaned(
     ctx: &ReplyContext,
-    result: AnomalyResult,
-    samples: Vec<Sample>,
+    result: &AnomalyResult,
+    samples: &[Sample],
     direction: AnomalyDirection,
 ) -> ValkeyResult {
-    ctx.reply_with_map(2);
-    ctx.reply_with_string("samples");
-    reply_with_cleaned_samples(ctx, &samples, &result.anomalies, direction);
-    ctx.reply_with_string("outliers");
-    reply_with_anomalies(ctx, &result, &samples, direction);
+    reply_with_cleaned_samples(ctx, samples, &result.anomalies, direction);
     Ok(ValkeyValue::NoReply)
 }
 

--- a/tests/outlier_result.py
+++ b/tests/outlier_result.py
@@ -32,6 +32,16 @@ def to_str(value: Any) -> str:
     return str(value)
 
 
+def _to_float_if_numeric(v: Any) -> Any:
+    """Converts bytes to float if they represent a numeric value."""
+    if isinstance(v, bytes):
+        try:
+            return float(v)
+        except (ValueError, TypeError):
+            return v
+    return v
+
+
 def maybe_map_from_kv_array(value: Any) -> Any:
     """Convert a flat key/value array into a dict when needed.
 
@@ -45,7 +55,9 @@ def maybe_map_from_kv_array(value: Any) -> Any:
         if len(value) % 2 != 0:
             raise ValueError("Invalid key-value array length")
         for i in range(0, len(value), 2):
-            out[to_str(value[i])] = value[i + 1]
+            key = to_str(value[i])
+            val = _to_float_if_numeric(value[i + 1])
+            out[key] = val
         return out
     return value
 
@@ -108,26 +120,42 @@ class AnomalyMethod(Enum):
 class Sample:
     """A single time-series sample.
 
-    Represented as a tuple/array in replies: [timestamp, value] or
-    [timestamp, value, score]. The optional `score` holds an anomaly
-    score when present.
+    Represented as a tuple/array in replies: [timestamp, value],
+    [timestamp, value, score], or [timestamp, value, score, signal].
     """
 
     timestamp: int
     value: float
     score: Optional[float] = None
+    signal: AnomalySignal = 0  # type: ignore[assignment]
+
+    def is_positive_anomaly(self) -> bool:
+        return self.signal == 1
+
+    def is_negative_anomaly(self) -> bool:
+        return self.signal == -1
+
+    def is_anomalous(self) -> bool:
+        return self.signal != 0
 
     @staticmethod
     def parse(value: Any) -> "Sample":
-        if not isinstance(value, Sequence) or (len(value) != 2 and len(value) != 3):
-            raise TypeError("Sample must be a 2- or 3-item array: [timestamp, value, score?]")
+        if not isinstance(value, Sequence) or len(value) not in (2, 3, 4):
+            raise TypeError("Sample must be [timestamp, value], [timestamp, value, score], or [timestamp, value, score, signal]")
         timestamp = to_int(value[0])
         val = to_float(value[1])
         score = None
+        signal: AnomalySignal = 0  # type: ignore[assignment]
         if len(value) == 3:
             score = to_float(value[2])
+        elif len(value) == 4:
+            score = to_float(value[2])
+            signal_int = to_int(value[3])
+            if signal_int not in (-1, 0, 1):
+                raise ValueError(f"Invalid sample signal: {signal_int}")
+            signal = signal_int  # type: ignore[assignment]
 
-        return Sample(timestamp=timestamp, value=val, score=score)
+        return Sample(timestamp=timestamp, value=val, score=score, signal=signal)
 
 
 @dataclass(frozen=True, slots=True)
@@ -195,20 +223,21 @@ MethodInfo = Union[MethodInfoFenced, MethodInfoSpc, MethodInfoIsolationForest]
 @dataclass(frozen=True, slots=True)
 class TSOutliersFullResult:
     method: AnomalyMethod
-    threshold: float
+    parameters: dict[str, Any]
     samples: List[Sample]
-    anomalies: List[AnomalyEntry]
     method_info: Optional[MethodInfo] = None
+    threshold: Optional[float] = None  # Legacy, for backward compatibility
+
     @staticmethod
     def parse(value: Any) -> TSOutliersFullResult:
         """
         Parse a Valkey client response for `TS.OUTLIERS ... FORMAT full`.
 
         Expected shape (as Python types):
-        - dict with keys: method, threshold, samples, outliers (or legacy 'anomalies'), optional method_info
-        - samples: list of [timestamp, value, score?]
-        - outliers / anomalies: list of [timestamp, value, signal, score]
+        - dict with keys: method, parameters, samples, optional method_info
+        - samples: list of [timestamp, value, score, signal]
           where `signal` is one of -1, 0, 1
+        - optional legacy outliers/anomalies list: [timestamp, value, signal, score]
         - method_info: dict with one of:
             * {lower_fence, upper_fence}
             * {control_limits: [low, high], center_line}
@@ -221,17 +250,28 @@ class TSOutliersFullResult:
             raise TypeError(f"Expected dict for FORMAT full result, got {type(value)!r}")
 
         method = AnomalyMethod.parse(value.get("method"))
-        threshold = to_float(value.get("threshold"))
+        parameters = maybe_map_from_kv_array(value.get("parameters", {}))
+
+        # For backward compatibility, some tests might still rely on a top-level threshold
+        threshold = parameters.get("threshold")
 
         raw_samples = value.get("samples") or []
         samples: List[Sample] = [Sample.parse(pair) for pair in raw_samples]
 
-        # Accept either 'outliers' or legacy 'anomalies' key for anomaly entries
+        # Backfill signal metadata from legacy outliers for older shapes that omit sample signal.
         anomalies_raw = value.get("outliers") or value.get("anomalies") or []
-        anomalies: List[AnomalyEntry] = []
-        for raw_anomaly in anomalies_raw:
-            anomaly = AnomalyEntry.parse(raw_anomaly)
-            anomalies.append(anomaly)  # type: ignore[arg-type]
+        if anomalies_raw and all(sample.signal == 0 for sample in samples):
+            parsed_anomalies = [AnomalyEntry.parse(item) for item in anomalies_raw]
+            by_ts: dict[int, AnomalyEntry] = {item.timestamp: item for item in parsed_anomalies}
+            samples = [
+                Sample(
+                    timestamp=sample.timestamp,
+                    value=sample.value,
+                    score=sample.score if sample.score is not None else by_ts[sample.timestamp].score if sample.timestamp in by_ts else None,
+                    signal=by_ts[sample.timestamp].signal if sample.timestamp in by_ts else 0,
+                )
+                for sample in samples
+            ]
 
         method_info_val = value.get("method_info")
         method_info: Optional[MethodInfo] = None
@@ -247,21 +287,19 @@ class TSOutliersFullResult:
                     control_limits=(to_float(cl[0]), to_float(cl[1])),
                     center_line=to_float(method_info_val["center_line"]),
                 )
-            elif "average_path_length" in method_info_val:
-                method_info = MethodInfoIsolationForest(
-                    average_path_length=to_float(method_info_val["average_path_length"])
-                )
-
         return TSOutliersFullResult(
             method=method,
-            threshold=threshold,
+            parameters=parameters,
             samples=samples,
-            anomalies=anomalies,
             method_info=method_info,
+            threshold=threshold,
         )
 
+    def anomalies(self) -> List[Sample]:
+        return [sample for sample in self.samples if sample.signal != 0]
+
     def anomaly_count(self) -> int:
-        return len(self.anomalies)
+        return len(self.anomalies())
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/outlier_result.py
+++ b/tests/outlier_result.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 """Helpers to parse TS.OUTLIERS test responses.
 
@@ -308,42 +308,26 @@ class TSOutliersCleanedResult:
 
     Attributes:
         samples: List of samples with anomalies removed (cleaned data)
-        anomalies: List of detected anomaly entries
     """
     samples: List[Sample]
-    anomalies: List[AnomalyEntry]
 
     @staticmethod
     def parse(value: Any) -> "TSOutliersCleanedResult":
         """Parse the raw Valkey response into a TSOutliersCleanedResult.
 
-        Accepts responses shaped either with an 'outliers' key (preferred) or
-        a legacy 'anomalies' key for the list of anomaly entries.
+        FORMAT cleaned now returns only an array of cleaned samples.
         """
-        value = maybe_map_from_kv_array(value)
+        if not isinstance(value, Sequence):
+            raise TypeError("FORMAT cleaned result must be an array of samples")
 
-        if not isinstance(value, Mapping):
-            raise TypeError("FORMAT cleaned result must be a map with keys: samples and outliers/anomalies")
+        samples = [Sample.parse(item) for item in value]
 
-        raw_samples = value.get("samples") or []
-        raw_anomalies = value.get("outliers") or value.get("anomalies") or []
-
-        samples = [Sample.parse(item) for item in raw_samples]
-        anomalies = [AnomalyEntry.parse(item) for item in raw_anomalies]
-
-        return TSOutliersCleanedResult(samples=samples, anomalies=anomalies)
-
-    def anomaly_count(self) -> int:
-        """Return the number of detected anomalies."""
-        return len(self.anomalies)
+        return TSOutliersCleanedResult(samples=samples)
 
     def sample_count(self) -> int:
         """Return the number of cleaned samples."""
         return len(self.samples)
 
-    def anomaly_values(self) -> List[float]:
-        """Return the list of anomaly values."""
-        return [entry.value for entry in self.anomalies]
 
     def sample_values(self) -> List[float]:
         """Return list of cleaned sample values."""

--- a/tests/outlier_result.py
+++ b/tests/outlier_result.py
@@ -249,8 +249,9 @@ class TSOutliersFullResult:
         if not isinstance(value, dict):
             raise TypeError(f"Expected dict for FORMAT full result, got {type(value)!r}")
 
-        method = AnomalyMethod.parse(value.get("method"))
+
         parameters = maybe_map_from_kv_array(value.get("parameters", {}))
+        method = AnomalyMethod.parse(value.get("method"))
 
         # For backward compatibility, some tests might still rely on a top-level threshold
         threshold = parameters.get("threshold")
@@ -273,7 +274,7 @@ class TSOutliersFullResult:
                 for sample in samples
             ]
 
-        method_info_val = value.get("method_info")
+        method_info_val = maybe_map_from_kv_array(value.get("method_info"))
         method_info: Optional[MethodInfo] = None
         if isinstance(method_info_val, dict):
             if "lower_fence" in method_info_val and "upper_fence" in method_info_val:

--- a/tests/test_ts_outliers.py
+++ b/tests/test_ts_outliers.py
@@ -551,20 +551,19 @@ class TestOutliersMethods(ValkeyTimeSeriesTestCaseBase):
         # Basic structure checks
         assert len(result.samples) > 500
         assert result.method.value == "ZScore"
-        assert result.threshold == 3.0
-
-        # Find the spike in the returned samples
-        spike_sample = next((s for s in result.samples if s.timestamp == spike_ts), None)
-        assert spike_sample is not None, f"Spike timestamp {spike_ts} not found in samples"
-        assert spike_sample.value == 500.0
+        assert result.parameters["threshold"] == 3.0
+        anomalies = result.anomalies()
+        assert anomalies, "Expected at least one anomaly"
+        assert anomalies[0].timestamp == spike_ts
+        assert anomalies[0].value == 500.0
 
         # The anomaly should be returned in the outliers structure
-        assert len(result.anomalies) == 1, f"Expected one anomaly, got {result.anomalies}"
-        anomaly = result.anomalies[0]
+        assert len(result.anomalies()) == 1, f"Expected one anomaly, got {result.anomalies()}"
+        anomaly = result.anomalies()[0]
         assert anomaly.timestamp == spike_ts
         assert anomaly.value == 500.0
         assert anomaly.signal == 1
-        assert anomaly.is_positive()
+        assert anomaly.is_positive_anomaly()
 
 
 
@@ -647,31 +646,19 @@ class TestOutliersMethods(ValkeyTimeSeriesTestCaseBase):
 
         # basic checks
         assert result.method.value == "ZScore", f"unexpected method {result.method}"
-        assert abs(result.threshold - 3.0) < 1e-12, f"unexpected threshold {result.threshold}"
+        assert abs(result.parameters["threshold"] - 3.0) < 1e-12, f"unexpected threshold {result.parameters['threshold']}"
+        # Seasonal decomposition can surface extra edge anomalies; require at least the injected spikes.
+        assert len(result.anomalies()) >= 3, f"expected at least 3 anomalies, got {len(result.anomalies())}"
 
-        print(f"Items len = {len(items)}")
-
-        # ensure returned sample list aligns with stored samples (see explanation re: zip)
-        assert len(result.samples) == stored_count, (
-            f"full.samples length ({len(result.samples)}) != stored_count ({stored_count})"
-        )
-
-        # collect anomaly values/timestamps
-        anomaly_values = [a.value for a in result.anomalies]
-        anomaly_timestamps = [a.timestamp for a in result.anomalies]
-
-        # At minimum expect the injected spikes to appear in the anomalies list; check presence, but be tolerant to detector sensitivity:
-        expect_values = {400.0, -50.0, 380.0}
-        found_values = set(v for v in anomaly_values if any(abs(v - ev) < 1e-8 for ev in expect_values))
-        assert found_values, f"None of the expected anomalies {expect_values} were detected. Found anomalies (values): {anomaly_values}"
-
-        # Prefer at least 2 of the 3 to be detected (robust but strict enough)
-        matches = sum(1 for ev in expect_values if any(abs(a.value - ev) < 1e-8 for a in result.anomalies))
-        assert matches >= 2, f"Expected to detect at least 2 of {expect_values}, detected {matches}; anomalies: {result.anomalies}"
+        # Verify anomaly details
+        anomaly_values = [a.value for a in result.anomalies()]
+        assert any(abs(v - 400.0) < 1e-8 for v in anomaly_values)
+        assert any(abs(v + 50.0) < 1e-8 for v in anomaly_values)
+        assert any(abs(v - 380.0) < 1e-8 for v in anomaly_values)
 
         # verify positive/negative signal distribution
-        positive_anomalies = [a for a in result.anomalies if a.signal == 1]
-        negative_anomalies = [a for a in result.anomalies if a.signal == -1]
+        positive_anomalies = [a for a in result.anomalies() if a.signal == 1]
+        negative_anomalies = [a for a in result.anomalies() if a.signal == -1]
         assert len(positive_anomalies) >= 1, f"expected at least one positive anomaly, got {positive_anomalies}"
         assert len(negative_anomalies) >= 1, f"expected at least one negative anomaly, got {negative_anomalies}"
 

--- a/tests/test_ts_outliers.py
+++ b/tests/test_ts_outliers.py
@@ -428,7 +428,7 @@ class TestOutliersMethods(ValkeyTimeSeriesTestCaseBase):
         assert len(result) == 0
 
     def test_format_cleaned(self):
-        """Test OUTPUT cleaned returns samples without anomalies and anomaly list."""
+        """Test OUTPUT cleaned returns only samples with directed anomalies removed."""
         key = 'test:outliers:format:cleaned'
 
         # Create data with clear anomalies
@@ -450,22 +450,23 @@ class TestOutliersMethods(ValkeyTimeSeriesTestCaseBase):
             'METHOD', 'zscore', 'THRESHOLD', '2.5'
         )
 
-        # The result should be a map with 'samples' and 'anomalies' keys
+        # CLEANED is an array of [timestamp, value] samples
         result = TSOutliersCleanedResult.parse(result)
+        anomalies_both = convert_anomaly_entries(
+            self.client.execute_command(
+                'TS.OUTLIERS', key, '-', '+',
+                'OUTPUT', 'simple',
+                'METHOD', 'zscore', 'THRESHOLD', '2.5'
+            )
+        )
 
-        anomaly_values = [float(a.value) for a in result.anomalies]
-
-        # Anomalies should contain the outliers (50.0 and -30.0)
-        assert result.anomaly_count() == 2
-
-        assert 50.0 in anomaly_values
-        assert -30.0 in anomaly_values
+        assert len(anomalies_both) == 2
 
         # Cleaned samples should exclude anomalies
         sample_values = [s.value for s in result.samples]
         assert 50.0 not in sample_values
         assert -30.0 not in sample_values
-        assert len(sample_values) == len(data) - 2  # Total minus anomalies
+        assert len(sample_values) == len(data) - len(anomalies_both)
 
         # Test OUTPUT cleaned with DIRECTION positive (only removes positive anomalies)
         result_positive = self.client.execute_command(
@@ -477,7 +478,14 @@ class TestOutliersMethods(ValkeyTimeSeriesTestCaseBase):
 
         res = TSOutliersCleanedResult.parse(result_positive)
         samples_pos = res.samples
-        anomalies_pos = res.anomalies
+        anomalies_pos = convert_anomaly_entries(
+            self.client.execute_command(
+                'TS.OUTLIERS', key, '-', '+',
+                'OUTPUT', 'simple',
+                'DIRECTION', 'positive',
+                'METHOD', 'zscore', 'THRESHOLD', '2.5'
+            )
+        )
 
         assert len(anomalies_pos) == 1
         assert anomalies_pos[0].value == 50.0
@@ -499,7 +507,14 @@ class TestOutliersMethods(ValkeyTimeSeriesTestCaseBase):
 
         res = TSOutliersCleanedResult.parse(result_negative)
         samples_neg = res.samples
-        anomalies_neg = res.anomalies
+        anomalies_neg = convert_anomaly_entries(
+            self.client.execute_command(
+                'TS.OUTLIERS', key, '-', '+',
+                'OUTPUT', 'simple',
+                'DIRECTION', 'negative',
+                'METHOD', 'zscore', 'THRESHOLD', '2.5'
+            )
+        )
 
         assert len(anomalies_neg) == 1
         assert anomalies_neg[0].value == -30.0

--- a/tests/test_ts_outliers_rcf.py
+++ b/tests/test_ts_outliers_rcf.py
@@ -333,7 +333,7 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
     # ── OUTPUT format: cleaned ────────────────────────────────────────────────
 
     def test_rcf_output_cleaned_excludes_anomalies_from_samples(self):
-        """OUTPUT cleaned: anomalous samples are absent from the samples list."""
+        """OUTPUT cleaned: response is cleaned samples only, without anomaly entries."""
         key = "rcf:output_cleaned:exclude"
         data = [10.0] * 120
         data[50] = 500.0
@@ -351,12 +351,15 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
         )
         result = TSOutliersCleanedResult.parse(raw)
 
+        assert isinstance(raw, list)
+        assert all(len(item) == 2 for item in raw)
+
         sample_values = result.sample_values()
         assert 500.0 not in sample_values, "spike at index 50 must be excluded from cleaned samples"
         assert 600.0 not in sample_values, "spike at index 90 must be excluded from cleaned samples"
 
     def test_rcf_output_cleaned_samples_plus_anomalies_total_equals_input(self):
-        """OUTPUT cleaned: len(samples) + len(anomalies) == total input points."""
+        """OUTPUT cleaned: len(cleaned_samples) + len(simple_anomalies) == total input points."""
         key = "rcf:output_cleaned:count"
         n = 120
         data = [10.0] * n
@@ -364,7 +367,7 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
         data[90] = 600.0
         _add(self.client, key, 1_000, data)
 
-        raw = self.client.execute_command(
+        raw_cleaned = self.client.execute_command(
             "TS.OUTLIERS", key, "-", "+",
             "OUTPUT", "cleaned",
             "METHOD", "rcf",
@@ -373,9 +376,19 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
             "THRESHOLD", 3.0,
             "OUTPUT_AFTER", 30,
         )
-        result = TSOutliersCleanedResult.parse(raw)
+        raw_simple = self.client.execute_command(
+            "TS.OUTLIERS", key, "-", "+",
+            "OUTPUT", "simple",
+            "METHOD", "rcf",
+            "NUM_TREES", 100,
+            "SAMPLE_SIZE", 256,
+            "THRESHOLD", 3.0,
+            "OUTPUT_AFTER", 30,
+        )
+        result = TSOutliersCleanedResult.parse(raw_cleaned)
+        anomalies = _parse_anomalies(raw_simple)
 
-        assert result.sample_count() + result.anomaly_count() == n
+        assert result.sample_count() + len(anomalies) == n
 
     def test_rcf_output_cleaned_direction_positive_keeps_negative_anomaly(self):
         """OUTPUT cleaned with DIRECTION positive keeps negative anomalies in samples."""

--- a/tests/test_ts_outliers_rcf.py
+++ b/tests/test_ts_outliers_rcf.py
@@ -225,8 +225,12 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
         result = TSOutliersFullResult.parse(raw)
 
         assert result.method == AnomalyMethod.RANDOM_CUT_FOREST
-        assert result.threshold > 0.0
-        assert len(result.samples) == len(data)
+        assert result.parameters["threshold"] > 0.0
+        assert result.parameters["num_trees"] == 100
+        assert result.parameters["sample_size"] == 256
+        assert result.parameters["output_after"] == 30
+
+        assert len(result.samples) == 120
         # There should be at least one anomaly
         assert result.anomaly_count() >= 1
 
@@ -285,7 +289,7 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
         )
         result = TSOutliersFullResult.parse(raw)
 
-        for anomaly in result.anomalies:
+        for anomaly in result.anomalies():
             assert anomaly.score > 0.0, (
                 f"anomaly score {anomaly.score} should be positive"
             )
@@ -306,11 +310,12 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
                 "OUTPUT_AFTER", 20,
             )
             result = TSOutliersFullResult.parse(raw)
-            assert abs(result.threshold - t) < 1e-9, (
-                f"expected threshold {t}, got {result.threshold}"
+            assert "threshold" in result.parameters
+            assert abs(result.parameters["threshold"] - t) < 1e-9, (
+                f"expected threshold {t}, got {result.parameters['threshold']}"
             )
 
-        # Test CONTAMINATION
+        # Test CONTAMINATION (percentile-based)
         for c in (0.01, 0.05, 0.1):
             raw = self.client.execute_command(
                 "TS.OUTLIERS", key, "-", "+",
@@ -320,8 +325,9 @@ class TestRCFOutlierDetector(ValkeyTimeSeriesTestCaseBase):
                 "OUTPUT_AFTER", 20,
             )
             result = TSOutliersFullResult.parse(raw)
-            assert abs(result.threshold - c) < 1e-9, (
-                f"expected contamination {c} in threshold field, got {result.threshold}"
+            assert "contamination" in result.parameters
+            assert abs(result.parameters["contamination"] - c) < 1e-9, (
+                f"expected contamination {c}, got {result.parameters['contamination']}"
             )
 
     # ── OUTPUT format: cleaned ────────────────────────────────────────────────


### PR DESCRIPTION
This pull request makes several improvements and corrections to the TS.OUTLIERS command, focusing on cleaning up the output formats, improving API consistency, and enhancing test helpers. The most significant changes are in how the `FULL` and `CLEANED` output formats are structured and how method parameters are returned, as well as some code simplifications and documentation updates.

### Output format and API improvements

* The `FULL` output format now returns a simplified structure: the `samples` field includes tuples of `[timestamp, value, score, signal]`, and a new `parameters` map is added to describe the detection method parameters. The `threshold`, `scores`, and `outliers` fields are removed from the top-level output. Seasonality metadata is also optionally included. (`docs/commands/ts.outliers.md` [[1]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL259-R272) [[2]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL332-R346) [[3]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL715-L762) [[4]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccR847-R951) [[5]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL814-R836) [[6]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL606-R609)

* The `CLEANED` output format now returns only the cleaned (normal) samples as an array, rather than a map with both samples and outliers. (`docs/commands/ts.outliers.md` [[1]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL50-R50) [[2]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL259-R272) [[3]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL378-L392) `src/commands/ts_outliers.rs` [[4]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL646-R631)

### Internal refactoring and bugfixes

* The anomaly detection options and reply logic have been refactored to pass options more consistently and avoid unnecessary clones. The background execution threshold for lightweight methods has been reduced from 10,000 to 5,000 samples. (`src/commands/ts_outliers.rs` [[1]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL132-R130) [[2]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccR140) [[3]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL151-R165) [[4]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL179-R185)

* Removed unused helper functions and simplified argument parsing. (`src/commands/ts_outliers.rs` [[1]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL578-L591) [[2]](diffhunk://#diff-73062941c25b6e9a7c9e124569f5e6b61908343a7358ba31a2884764b7d8fcccL606-R609)

### Documentation and test improvements

* Documentation for the TS.OUTLIERS command has been updated to reflect the new output formats, parameter reporting, and improved clarity in method descriptions. (`docs/commands/ts.outliers.md` [docs/commands/ts.outliers.mdL89-R89](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL89-R89), F39e63e9L437R443)

* The test helper in `outlier_result.py` now automatically converts numeric values in key-value arrays to floats, improving test robustness and consistency. (`tests/outlier_result.py` [[1]](diffhunk://#diff-b0f1e1caf9afb27d83cf7564ed75b5f1d7eaac234ba0e602444f394d5158e538L5-R5) [[2]](diffhunk://#diff-b0f1e1caf9afb27d83cf7564ed75b5f1d7eaac234ba0e602444f394d5158e538R35-R44) [[3]](diffhunk://#diff-b0f1e1caf9afb27d83cf7564ed75b5f1d7eaac234ba0e602444f394d5158e538L48-R60)